### PR TITLE
Add instructions for cloning / branching (rather than forking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ICCS Summer School - Introduction to Git and Github - Practice
-This repo is used to practice forking and incorporating changes by a pull request.
+This repo is used to practice cloning, branching, and incorporating changes by a pull request.
 It contains files with arbitrary data that can be modified.
 
 It was originally used for the 2024 ICCS Summer School Git Introductory Course.
@@ -7,14 +7,19 @@ It was originally used for the 2024 ICCS Summer School Git Introductory Course.
 
 ## Instructions
 First, make sure you fulfill the [prerequisites](https://github.com/Cambridge-ICCS/Summer-school-Intro-Git/tree/main?tab=readme-ov-file#preparation-and-prerequisites).
-Then click 'Fork' to create a new forked repository under your own account.
 
-Next clone your new forked repository onto your own machine using the 'SSH' url (found under '<> Code').
+Clone the repository onto your own machine using the 'SSH' url (found under '<> Code').
 ```
-git clone git@github.com:your-username/your-repo.git
+git clone git@github.com:Cambridge-ICCS/Summer-School-Intro-Git-Practice
+```
+Make sure you do not clone inside an existing git repository.
+
+Next, create a new branch with `git checkout -b your-branch-name`, commit some changes, and push your new branch to GitHub:
+```
+git push --set-upstream origin your-branch-name
 ```
 
-Then, after making changes and pushing them to your forked repository, open a new pull request on the [original repository](https://github.com/Cambridge-ICCS/git-intro-iccs-summer-school-2024).
+Finally, open a new pull request for your branch on GitHub.
 
 
 ## Teaching material


### PR DESCRIPTION
I changed the instructions to instead perform cloning and branching rather than forking.